### PR TITLE
Upgrade base image, fix Pact install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # dmp-golang-ci image
-FROM circleci/golang:1.14
+FROM cimg/go:1.14
 
 # Install gorunpkg
 RUN go get github.com/vektah/gorunpkg
@@ -12,12 +12,16 @@ RUN go get -d -u -v github.com/golangci/golangci-lint/cmd/golangci-lint
 
 # Protobuf
 ENV PROTOC_ZIP=protoc-3.7.1-linux-x86_64.zip
-RUN curl -OL https://github.com/google/protobuf/releases/download/v3.7.1/$PROTOC_ZIP \ 
-    && sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
-    && sudo unzip -o $PROTOC_ZIP -d /usr/local include/* \
-    && rm -f $PROTOC_ZIP
+RUN curl -OL https://github.com/google/protobuf/releases/download/v3.7.1/$PROTOC_ZIP \
+  && sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
+  && sudo unzip -o $PROTOC_ZIP -d /usr/local include/* \
+  && rm -f $PROTOC_ZIP
 
 RUN go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 RUN go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
 RUN go get -u github.com/golang/protobuf/protoc-gen-go
-RUN go get -u github.com/pact-foundation/pact-go
+
+# Install Pact tooling
+RUN cd /home/circleci && \
+  curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | sh
+ENV PATH="${PATH}:/home/circleci/pact/bin"


### PR DESCRIPTION
* Change base image to cimg/go as recommended by CircleCI
* Fix formatting (auto)
* Install stand alone Pact tooling correctly